### PR TITLE
[Bugfix] Fixed version by adding prefix (Wine or Proton). Installation directory name is now version name.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -157,13 +157,7 @@ async function installVersion({
     throw new Error(`No download link provided for ${versionInfo.version}!`)
   }
 
-  // get name of the wine folder to install the selected version
-  const folderNameParts = versionInfo.download
-    .split('/') // split path
-    .slice(-1)[0] // get the archive name
-    .split('.') // split dots
-    .slice(0, -2) // remove the archive extensions (tar.xz or tar.gz)
-  const installSubDir = installDir + '/' + folderNameParts.join('.')
+  const installSubDir = installDir + '/' + versionInfo.version
 
   const sourceChecksum = versionInfo.checksum
     ? (

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -30,7 +30,9 @@ function fetchReleases({
       .then((data) => {
         for (const release of data.data) {
           const release_data = {} as VersionInfo
-          release_data.version = release.tag_name
+          release_data.version = type.includes('wine')
+            ? `Wine-${release.tag_name}`
+            : `Proton-${release.tag_name}`
           release_data.type = type
           release_data.date = release.published_at.split('T')[0]
           release_data.disksize = 0

--- a/test/main/install.test.ts
+++ b/test/main/install.test.ts
@@ -374,7 +374,7 @@ describe('Main - InstallVersion', () => {
       })
       .catch((error: Error) => {
         expect(error.message).toContain(
-          'Failed to make folder /home/niklas/Repository/wine-proton-downloader/test/main/test_install/Wine-1.2.3/invalid with:'
+          `Failed to make folder ${installDir}/Wine-1.2.3/invalid with:`
         )
       })
 


### PR DESCRIPTION
Version now have a 'Wine' or 'Proton' prefix according to type.
The installation directory has now the name of the version.