### PR TITLE
[Bugfix] Fixed handling if checksum is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroic-wine-downloader",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ async function getAvailableVersions({
       case Repositorys.WINEGE: {
         await fetchReleases({
           url: WINEGE_URL,
-          type: 'wine-ge',
+          type: 'Wine-GE',
           count: count
         })
           .then((fetchedReleases: VersionInfo[]) => {
@@ -67,7 +67,7 @@ async function getAvailableVersions({
       case Repositorys.PROTONGE: {
         await fetchReleases({
           url: PROTONGE_URL,
-          type: 'proton-ge',
+          type: 'Proton-GE',
           count: count
         })
           .then((fetchedReleases: VersionInfo[]) => {
@@ -81,7 +81,7 @@ async function getAvailableVersions({
       case Repositorys.PROTON: {
         await fetchReleases({
           url: PROTON_URL,
-          type: 'proton',
+          type: 'Proton',
           count: count
         })
           .then((fetchedReleases: VersionInfo[]) => {
@@ -95,7 +95,7 @@ async function getAvailableVersions({
       case Repositorys.WINELUTRIS: {
         await fetchReleases({
           url: WINELUTRIS_URL,
-          type: 'wine-lutris',
+          type: 'Wine-Lutris',
           count: count
         })
           .then((fetchedReleases: VersionInfo[]) => {
@@ -228,9 +228,15 @@ async function installVersion({
   hashSum.update(fileBuffer)
 
   const downloadChecksum = hashSum.digest('hex')
-  if (!sourceChecksum.includes(downloadChecksum)) {
-    unlinkFile(tarFile)
-    throw new Error('Checksum verification failed')
+  if (sourceChecksum) {
+    if (!sourceChecksum.includes(downloadChecksum)) {
+      unlinkFile(tarFile)
+      throw new Error('Checksum verification failed')
+    }
+  } else {
+    console.warn(
+      `No checksum provided. Download of ${versionInfo.version} could be invalid!`
+    )
   }
 
   // Unzip

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,14 @@
 /**
+ * Defines from where the version comes
+ */
+export type Type =
+  | 'Wine-GE'
+  | 'Proton-GE'
+  | 'Proton'
+  | 'Wine-Lutris'
+  | 'Wine-Kron4ek'
+
+/**
  * Interface contains information about a version
  * - version
  * - type (wine, proton, lutris, ge ...)
@@ -9,7 +19,7 @@
  */
 export interface VersionInfo {
   version: string
-  type: 'wine-ge' | 'proton-ge' | 'proton' | 'wine-lutris'
+  type: Type
   date: string
   download: string
   downsize: number

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,11 +1,11 @@
 import * as axios from 'axios'
 import { existsSync, statSync, unlinkSync } from 'graceful-fs'
 import { spawnSync, spawn } from 'child_process'
-import { ProgressInfo, State, VersionInfo } from './types'
+import { ProgressInfo, State, VersionInfo, Type } from './types'
 
 interface fetchProps {
   url: string
-  type: 'wine-ge' | 'proton-ge' | 'proton' | 'wine-lutris'
+  type: Type
   count: number
 }
 
@@ -30,7 +30,7 @@ function fetchReleases({
       .then((data) => {
         for (const release of data.data) {
           const release_data = {} as VersionInfo
-          release_data.version = type.includes('wine')
+          release_data.version = type.includes('Wine')
             ? `Wine-${release.tag_name}`
             : `Proton-${release.tag_name}`
           release_data.type = type

--- a/test/main/getter.test.ts
+++ b/test/main/getter.test.ts
@@ -64,6 +64,7 @@ describe('Main - GetAvailableVersions', () => {
 
   test('Invalid repository key returns nothing', async () => {
     axios.default.get = jest.fn()
+    console.warn = jest.fn()
 
     await getAvailableVersions({ repositorys: [-1] })
       .then((releases: VersionInfo[]) => {
@@ -75,5 +76,8 @@ describe('Main - GetAvailableVersions', () => {
       })
 
     expect(axios.default.get).not.toBeCalled()
+    expect(console.warn).toBeCalledWith(
+      'Unknown and not supported repository key passed! Skip fetch for -1'
+    )
   })
 })

--- a/test/main/install.test.ts
+++ b/test/main/install.test.ts
@@ -19,7 +19,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: '1.2.3',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: '',
       downsize: 100,
@@ -46,7 +46,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: '1.2.3',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: '',
       downsize: 100,
@@ -73,7 +73,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: '1.2.3',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: '',
       downsize: 100,
@@ -98,7 +98,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: '1.2.3',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: '',
       downsize: 100,
@@ -132,7 +132,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: '1.2.3',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: `file:///${__dirname}/../test_data/test.tar.gz`,
       downsize: 100,
@@ -172,6 +172,60 @@ describe('Main - InstallVersion', () => {
     expect(progress).toBeCalledWith('idle')
   })
 
+  test('install warns because no checksum provided', async () => {
+    const installDir = __dirname + '/test_install'
+    let failed = false
+    axios.default.get = jest.fn()
+    const progress = jest.fn()
+    console.warn = jest.fn()
+
+    if (!existsSync(installDir)) {
+      mkdirSync(installDir)
+    }
+
+    const releaseVersion: VersionInfo = {
+      version: '1.2.3',
+      type: 'Wine-GE',
+      date: '12/24/2021',
+      download: `file:///${__dirname}/../test_data/test.tar.gz`,
+      downsize: 100,
+      disksize: 0,
+      checksum: ''
+    }
+    await installVersion({
+      versionInfo: releaseVersion,
+      installDir: installDir,
+      onProgress: progress
+    })
+      .then((response) => {
+        expect(console.warn).toBeCalledWith(
+          'No checksum provided. Download of 1.2.3 could be invalid!'
+        )
+        expect(response.versionInfo.version).toBe(releaseVersion.version)
+      })
+      .catch(() => {
+        failed = true
+      })
+
+    if (existsSync(installDir)) {
+      rmSync(installDir, { recursive: true })
+    }
+
+    if (failed) {
+      throw Error('No error should be thrown!')
+    }
+
+    expect(axios.default.get).not.toBeCalledWith()
+
+    expect(progress).toBeCalledWith('downloading', {
+      percentage: expect.any(Number),
+      avgSpeed: expect.any(Number),
+      eta: expect.any(Number)
+    })
+    expect(progress).toBeCalledWith('unzipping')
+    expect(progress).toBeCalledWith('idle')
+  })
+
   test('install succeed because already exist', async () => {
     const installDir = __dirname + '/test_install'
     let failed = false
@@ -184,7 +238,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: 'Wine-1.2.3',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: `file:///${__dirname}/../test_data/test.tar.gz`,
       downsize: 100,
@@ -235,7 +289,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: 'Wine-1.2.3',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: `file:///${fileLink}`,
       downsize: 100,
@@ -302,7 +356,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: 'Wine-1.2.3',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: `file:///${fileLink}`,
       downsize: 100,
@@ -369,7 +423,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: 'Wine-1.2.3',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: `file:///${fileLink}`,
       downsize: 100,
@@ -433,7 +487,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: 'Wine-1.2.3',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: `file:///${fileLink}`,
       downsize: 100,
@@ -492,7 +546,7 @@ describe('Main - InstallVersion', () => {
 
     const releaseVersion: VersionInfo = {
       version: 'Wine-1.2.3/invalid',
-      type: 'wine-ge',
+      type: 'Wine-GE',
       date: '12/24/2021',
       download: `file:///${fileLink}`,
       downsize: 100,


### PR DESCRIPTION
Installation fails without a detailed error message.
Added a warning if checksum is undefined and still install wine version.